### PR TITLE
Fix release lag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ go 1.19
 replace github.com/spf13/viper => github.com/getporter/viper v1.7.1-porter.2.0.20210514172839-3ea827168363
 
 require (
-	get.porter.sh/magefiles v0.5.0
+	get.porter.sh/magefiles v0.5.1
 	get.porter.sh/porter v1.0.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.5.0 h1:Hy/DgS0l+9TlEKcHKMPBCpzIRCKUs13wasT+T8S6P+A=
-get.porter.sh/magefiles v0.5.0/go.mod h1:KzKenKVauKKDhZ5FERVhqSz8m/xVSsRzOPseDA4UDIE=
+get.porter.sh/magefiles v0.5.1 h1:TUDxM/JoQjGnQ0YHxWr+Ko4Y8h/ETAMgW38jzN3fgBM=
+get.porter.sh/magefiles v0.5.1/go.mod h1:KzKenKVauKKDhZ5FERVhqSz8m/xVSsRzOPseDA4UDIE=
 get.porter.sh/porter v1.0.9 h1:oRjK6cqDVxk2bNlwyWoyLdIYClYz5J4SmPjbxOOQLFE=
 get.porter.sh/porter v1.0.9/go.mod h1:NcH92u0q5Z7Wv1a9ErFTkCqD24RPoHyycdoUYV2O5ws=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=


### PR DESCRIPTION
Update to magefiles v0.5.1 which ensures that releases stay in draft until the assets are successfully uploaded.

Related to https://github.com/getporter/porter/issues/2723