### PR TITLE
Convert porter/skeletor to GitHub Actions

### DIFF
--- a/.github/workflows/skeletor.yml
+++ b/.github/workflows/skeletor.yml
@@ -1,0 +1,34 @@
+name: porter/skeletor
+on:
+  push:
+    branches:
+    - main
+    - v*
+  pull_request:
+    branches:
+    - main
+env:
+  PORTER_PACKAGE_REMOTE: https://github.com/getporter/test-packages.git
+  PORTER_RELEASE_REPOSITORY: github.com/getporter/skeletor
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # This item has no matching transformer
+#     - task: GoTool@0
+#       inputs:
+#         version: 1.19.2
+#       displayName: Install Go
+    - name: Configure Agent
+      run: go run mage.go ConfigureAgent
+    - name: Test
+      run: mage Test
+    - name: Cross Compile
+      run: mage XBuildAll
+    - name: Publish
+      if: success() && github.event_name != 'PullRequest'
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: mage Publish


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/getporter/porter/_build?definitionId=13) :tada:

## Manual steps

Perform the following steps to complete the migration:

### porter/skeletor
- [ ] Ensure secret is available: `${{ secrets.GITHUB_TOKEN }}`